### PR TITLE
Use UUID namespace for wiki links

### DIFF
--- a/pages/players/[playerSlug].tsx
+++ b/pages/players/[playerSlug].tsx
@@ -191,7 +191,7 @@ function PlayerDetails({ player, team }: PlayerDetailsProps) {
       </Heading>
       <Flex mb={2}>
         <NextLink
-          href={`${process.env.NEXT_PUBLIC_BLASEBALL_WIKI_URL}/${player.player_id}`}
+          href={`${process.env.NEXT_PUBLIC_BLASEBALL_WIKI_URL}/UUID:${player.player_id}`}
           passHref
         >
           <Link fontSize="md" isExternal textDecoration="underline">

--- a/pages/teams/[teamSlug].tsx
+++ b/pages/teams/[teamSlug].tsx
@@ -169,7 +169,7 @@ function TeamDetails({ team, teamIsValidating }: TeamDetailsProps) {
         </NextLink>
         <Box mx={1}>-</Box>
         <NextLink
-          href={`${process.env.NEXT_PUBLIC_BLASEBALL_WIKI_URL}/${team.team_id}`}
+          href={`${process.env.NEXT_PUBLIC_BLASEBALL_WIKI_URL}/UUID:${team.team_id}`}
           passHref
         >
           <Link fontSize="md" isExternal textDecoration="underline">


### PR DESCRIPTION
UUID redirects on the wiki are being moved out of the main namespace.